### PR TITLE
added parse_url() to simplify request()

### DIFF
--- a/urlfetch.py
+++ b/urlfetch.py
@@ -780,6 +780,9 @@ def parse_url(url):
     # TODO add extraction username and password from url, for example: http://username:password@host:port/
 
     result = dict()
+    if not url:
+        return result
+
     _scheme, _netloc, _path, _params, _query, _fragment = urlparse.urlparse(url)
     
     result['scheme'] = _scheme


### PR DESCRIPTION
new function parse_url() from one side can simplify request() function but from another side can be used for parsing any urls in future. For example: url to proxy server in format http://&lt;username&gt;:&lt;password&gt;@&lt;host&gt;:&lt;port&gt; (not implemented yet in current version of parse_url)
