### PR TITLE
urlsplit() instead of ulrparse() in parse_url()

### DIFF
--- a/urlfetch.py
+++ b/urlfetch.py
@@ -787,12 +787,11 @@ def parse_url(url):
     host and port
     '''
     result = dict()
-    parsed = urlparse.urlparse(url)
+    parsed = urlparse.urlsplit(url)
     
     result['scheme'] = parsed.scheme
     result['netloc'] = parsed.netloc
     result['path'] = parsed.path
-    result['params'] = parsed.params
     result['query'] = parsed.query
     result['fragment'] = parsed.fragment
     result['uri'] = parsed.path


### PR DESCRIPTION
http://docs.python.org/library/urlparse.html#urlparse.urlsplit 

In this case we can avoid to use "params"
