### PR TITLE
Test case for proxy support added + fix one issue with proxy format

### DIFF
--- a/tests/server.py
+++ b/tests/server.py
@@ -69,6 +69,11 @@ def setcookie(name, value):
     return normal_formsdict()
 
 
+@app.route('http://www.example.com', method=['GET', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'PATCH'])
+def index():
+    return normal_formsdict()
+
+
 import sys
 try:
     port = int(sys.argv[1])

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,14 @@
+import testlib
+import urlfetch
+import unittest
+
+
+class ProxyTest(unittest.TestCase):
+
+    def test_get_via_proxy(self):
+        resp = urlfetch.get('http://www.example.com', proxies={'http':testlib.test_server_host})
+        print resp
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/urlfetch.py
+++ b/urlfetch.py
@@ -838,8 +838,8 @@ def parse_url(url):
 def get_proxies_from_environ():
     '''get proxies from os.environ'''
     proxies = {}
-    http_proxy = os.environ.get('http_proxy') or os.environ.get('HTTP_PROXY')
-    https_proxy = os.environ.get('https_proxy') or os.environ.get('HTTPS_PROXY')
+    http_proxy = os.getenv('http_proxy') or os.getenv('HTTP_PROXY')
+    https_proxy = os.getenv('https_proxy') or os.getenv('HTTPS_PROXY')
     if http_proxy:
         proxies['http'] = http_proxy
     if https_proxy:


### PR DESCRIPTION
The format HTTP_PROXY is 'scheme://proxy_host:proxy_port'
