### PR TITLE
add "lazy response" support

### DIFF
--- a/tests/test_lazy.py
+++ b/tests/test_lazy.py
@@ -1,0 +1,40 @@
+import testlib
+import urlfetch
+import unittest
+import time
+import json
+import socket
+
+class LazyTest(unittest.TestCase):
+
+    def test_lazy(self):
+
+        time1 = time.time()
+        r = urlfetch.get(testlib.test_server_host + 'sleep/2', lazy=True)
+        time2 = time.time()
+
+        self.assertLess(time2 - time1, 1)
+        
+        time.sleep(2)
+
+        time3 = time.time()
+        o = json.loads(r.text)
+        time4 = time.time()
+
+        self.assertLess(time4 - time3, 1)
+        self.assertEqual(r.status, 200)
+        self.assertEqual(o['method'], 'GET')
+
+    def test_timeout(self):
+        r = urlfetch.get(testlib.test_server_host + 'sleep/1', lazy=True)
+        r.timeout = 0.5
+        self.assertRaises(socket.timeout, lambda: r.text)
+
+        r = urlfetch.get(testlib.test_server_host + 'sleep/1', lazy=True)
+        r.timeout = 0.5
+        time.sleep(2)
+        self.assertEqual(r.status, 200)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
用途：调用第三方接口时，可以先向第三方发送请求然后去干别的事，干完之后再获取response。

用法：

```
# send request
r = urlfetch.get('http://third-party-url/', lazy=True)

# do other stuff
data1 = query_database()

# get response
print r.text, data1
```
