### PR TITLE
Update urlfetch.py

### DIFF
--- a/urlfetch.py
+++ b/urlfetch.py
@@ -602,7 +602,7 @@ def request(url, method="GET", params=None, data=None, headers={}, timeout=None,
         'Accept-Encoding': 'gzip, deflate, compress, identity, *',
         'User-Agent': random_useragent(randua_file) if randua else \
                         'urlfetch/' + __version__,
-        'Host': parsed_url['host'],
+        'Host': parsed_url['host'] + ":%d"%parsed_url['port'] if parsed_url['port'] else "",
     }
 
     # Proxy support


### PR DESCRIPTION
按照http协议，非默认端口，应该在header中的host带上port。由于没有加上这个port，导致应用该包的一个http服务不能正常工作，后来改用urllib，一切正常。今天有时间好好看你的代码，发现了这个问题，修正之后，再次使用你的urlfetch，ok了。
